### PR TITLE
Scarecrow's Song Sync

### DIFF
--- a/API/src/OOT/OOTAPI.ts
+++ b/API/src/OOT/OOTAPI.ts
@@ -460,7 +460,6 @@ export interface ISaveContext {
   keyManager: IKeyManager;
   dungeonItemManager: IDungeonItemManager;
   scarecrowsSongChildFlag: boolean;
-  scarecrowsSongAdultFlag: boolean;
   scarecrowsSong: Buffer;
   double_defense: number;
   bButton: number;

--- a/API/src/OOT/OOTAPI.ts
+++ b/API/src/OOT/OOTAPI.ts
@@ -459,6 +459,8 @@ export interface ISaveContext {
   skulltulaFlags: Buffer;
   keyManager: IKeyManager;
   dungeonItemManager: IDungeonItemManager;
+  scarecrowsSongChildFlag: boolean;
+  scarecrowsSong: Buffer;
   double_defense: number;
   bButton: number;
 }
@@ -765,5 +767,77 @@ export class SceneStruct {
 
   get visited_floors(): Buffer {
     return this.buf.slice(0x18, 0x1C);
+  }
+}
+
+export const enum SongNotes {
+  NONE = 0,
+  A_FLAT = 1,
+  A_NOTE = 2,
+  A_SHARP = 3,
+  C_DOWN_FLAT = 4,
+  C_DOWN_NOTE = 5,
+  C_DOWN_SHARP = 6,
+  C_RIGHT_FLAT = 8,
+  C_RIGHT_NOTE = 9,
+  C_RIGHT_SHARP = 10,
+  C_LEFT_FLAT = 10,
+  C_LEFT_NOTE = 11,
+  C_LEFT_SHARP = 12,
+  C_UP_FLAT = 13,
+  C_UP_NOTE = 14,
+  C_UP_SHARP = 15,
+  SILENCE = 0xFF,
+}
+
+export const enum SongFlags {
+  NONE = 0,
+  FLATTENED_NOTE = 0x40,
+  SHARPENED_NOTE = 0x80,
+  CONTINUE_SILENCE = 0xC0,
+}
+
+export interface IScarecrowSongNote {
+  note: SongNotes;
+  duration: number;
+  volume: number;
+  vibrato: number;
+  pitch: number;
+  special: SongFlags;
+}
+
+export class ScarecrowSongNoteStruct {
+  buf: Buffer;
+
+  constructor(buf: Buffer) {
+    this.buf = buf;
+  }
+
+  get note(): Buffer {
+    return this.buf.slice(0x0, 0x1);
+  }
+
+  get unused(): Buffer {
+    return this.buf.slice(0x1, 0x2);
+  }
+
+  get duration(): Buffer {
+    return this.buf.slice(0x2, 0x4);
+  }
+
+  get volume(): Buffer {
+    return this.buf.slice(0x4, 0x5);
+  }
+
+  get vibrato(): Buffer {
+    return this.buf.slice(0x5, 0x6);
+  }
+
+  get pitch(): Buffer {
+    return this.buf.slice(0x6, 0x7);
+  }
+
+  get special(): Buffer {
+    return this.buf.slice(0x7, 0x8);
   }
 }

--- a/API/src/OOT/OOTAPI.ts
+++ b/API/src/OOT/OOTAPI.ts
@@ -460,6 +460,7 @@ export interface ISaveContext {
   keyManager: IKeyManager;
   dungeonItemManager: IDungeonItemManager;
   scarecrowsSongChildFlag: boolean;
+  scarecrowsSongAdultFlag: boolean;
   scarecrowsSong: Buffer;
   double_defense: number;
   bButton: number;

--- a/src/modloader/cores/OOT/Link.ts
+++ b/src/modloader/cores/OOT/Link.ts
@@ -189,6 +189,8 @@ export class Link extends JSONTemplate implements ILink {
             return LinkState.GETTING_ITEM;
         case 0x20010040:
             return LinkState.TALKING;
+        case 0x30010040:
+            return LinkState.TALKING; // While presenting item?
         case 0x00018000:
             return LinkState.Z_TARGETING;
         case 0x00028000:

--- a/src/modloader/cores/OOT/SaveContext.ts
+++ b/src/modloader/cores/OOT/SaveContext.ts
@@ -40,7 +40,7 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     private magic_limit_addr: number = this.instance + 0x13f4;
     private magic_flag_1_addr: number = this.instance + 0x003a;
     private magic_flag_2_addr: number = this.instance + 0x003c;
-    private magic_fill_cap_addr: number = 0x8011B9C7;
+    private magic_fill_cap_addr: number = this.instance + 0x13f7;
     private rupees_address: number = this.instance + 0x0034;
     private navi_timer_addr: number = this.instance + 0x0038;
     private checksum_addr: number = this.instance + 0x1352;
@@ -53,6 +53,8 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     private skulltula_table_addr: number = this.instance + 0x0e9c;
     private scarecrowsSongChildFlag_addr: number = this.instance + 0x12c4;
     private scarecrowsSong_addr: number = this.instance + 0x12c6;
+    private scarecrowsSong_addr_1: number = 0x801029FC;
+    private scarecrowsSong_addr_2: number = 0x80102A9C;
     private double_defense_addr_1: number = this.instance + 0x00cf;
     private double_defense_addr_2: number = this.instance + 0x3d;
 
@@ -292,6 +294,8 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     }
     set scarecrowsSong(buf: Buffer) {
         this.emulator.rdramWriteBuffer(this.scarecrowsSong_addr, buf);
+        this.emulator.rdramWriteBuffer(this.scarecrowsSong_addr_1, buf);
+        this.emulator.rdramWriteBuffer(this.scarecrowsSong_addr_2, buf);
     }
     get double_defense(): number {
         return this.emulator.rdramRead8(this.double_defense_addr_1);

--- a/src/modloader/cores/OOT/SaveContext.ts
+++ b/src/modloader/cores/OOT/SaveContext.ts
@@ -52,6 +52,7 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     private inf_table_addr: number = this.instance + 0x0ef8;
     private skulltula_table_addr: number = this.instance + 0x0e9c;
     private scarecrowsSongChildFlag_addr: number = this.instance + 0x12c4;
+    private scarecrowsSongAdultFlag_addr: number = this.instance + 0xee6;
     private scarecrowsSong_addr: number = this.instance + 0x12c6;
     private scarecrowsSong_addr_1: number = 0x801029FC;
     private scarecrowsSong_addr_2: number = 0x80102A9C;
@@ -94,6 +95,7 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
         'magic_beans_purchased',
         'poe_collector_score',
         'scarecrowsSongChildFlag',
+        'scarecrowsSongAdultFlag',
         'scarecrowsSong'
     ];
     constructor(ModLoader: IModLoaderAPI, log: ILogger) {
@@ -288,6 +290,9 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
                 return bool ? 1 : 0;
             })(bool)
         );
+    }
+    get scarecrowsSongAdultFlag(): boolean {
+        return this.emulator.rdramReadBit8(this.scarecrowsSongAdultFlag_addr, 4);
     }
     get scarecrowsSong(): Buffer {
         return this.emulator.rdramReadBuffer(this.scarecrowsSong_addr, 0x7E);

--- a/src/modloader/cores/OOT/SaveContext.ts
+++ b/src/modloader/cores/OOT/SaveContext.ts
@@ -51,6 +51,8 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     private item_flag_addr: number = this.instance + 0x0ef0;
     private inf_table_addr: number = this.instance + 0x0ef8;
     private skulltula_table_addr: number = this.instance + 0x0e9c;
+    private scarecrowsSongChildFlag_addr: number = this.instance + 0x12c4;
+    private scarecrowsSong_addr: number = this.instance + 0x12c6;
     private double_defense_addr_1: number = this.instance + 0x00cf;
     private double_defense_addr_2: number = this.instance + 0x3d;
 
@@ -89,6 +91,8 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
         'questStatus',
         'magic_beans_purchased',
         'poe_collector_score',
+        'scarecrowsSongChildFlag',
+        'scarecrowsSong'
     ];
     constructor(ModLoader: IModLoaderAPI, log: ILogger) {
         super();
@@ -271,6 +275,23 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     }
     set skulltulaFlags(buf: Buffer) {
         this.emulator.rdramWriteBuffer(this.skulltula_table_addr, buf);
+    }
+    get scarecrowsSongChildFlag(): boolean {
+        return this.emulator.rdramRead16(this.scarecrowsSongChildFlag_addr) === 1;
+    }
+    set scarecrowsSongChildFlag(bool: boolean) {
+        this.emulator.rdramWrite16(
+            this.scarecrowsSongChildFlag_addr,
+            (function (bool: boolean) {
+                return bool ? 1 : 0;
+            })(bool)
+        );
+    }
+    get scarecrowsSong(): Buffer {
+        return this.emulator.rdramReadBuffer(this.scarecrowsSong_addr, 0x7E);
+    }
+    set scarecrowsSong(buf: Buffer) {
+        this.emulator.rdramWriteBuffer(this.scarecrowsSong_addr, buf);
     }
     get double_defense(): number {
         return this.emulator.rdramRead8(this.double_defense_addr_1);

--- a/src/modloader/cores/OOT/SaveContext.ts
+++ b/src/modloader/cores/OOT/SaveContext.ts
@@ -52,7 +52,6 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
     private inf_table_addr: number = this.instance + 0x0ef8;
     private skulltula_table_addr: number = this.instance + 0x0e9c;
     private scarecrowsSongChildFlag_addr: number = this.instance + 0x12c4;
-    private scarecrowsSongAdultFlag_addr: number = this.instance + 0xee6;
     private scarecrowsSong_addr: number = this.instance + 0x12c6;
     private scarecrowsSong_addr_1: number = 0x801029FC;
     private scarecrowsSong_addr_2: number = 0x80102A9C;
@@ -95,7 +94,6 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
         'magic_beans_purchased',
         'poe_collector_score',
         'scarecrowsSongChildFlag',
-        'scarecrowsSongAdultFlag',
         'scarecrowsSong'
     ];
     constructor(ModLoader: IModLoaderAPI, log: ILogger) {
@@ -291,11 +289,8 @@ export class SaveContext extends JSONTemplate implements ISaveContext {
             })(bool)
         );
     }
-    get scarecrowsSongAdultFlag(): boolean {
-        return this.emulator.rdramReadBit8(this.scarecrowsSongAdultFlag_addr, 4);
-    }
     get scarecrowsSong(): Buffer {
-        return this.emulator.rdramReadBuffer(this.scarecrowsSong_addr, 0x7E);
+        return this.emulator.rdramReadBuffer(this.scarecrowsSong_addr, 0x80);
     }
     set scarecrowsSong(buf: Buffer) {
         this.emulator.rdramWriteBuffer(this.scarecrowsSong_addr, buf);


### PR DESCRIPTION
Testing shows this works locally, but might need actual exposure to unexpected situations to buff out any unexpected situations.

Some unrelated work was done as well, adding a new LinkState.TALKING case and changing an absolute address to a pointer'd one in SaveContext. Both can be safely removed without affecting the Scarecrow's Song sync if needed or wanted.

Related PR on the OoTO Core: 